### PR TITLE
Modify Docker workflows to push to DockerHub

### DIFF
--- a/.github/workflows/docker-pr.yaml
+++ b/.github/workflows/docker-pr.yaml
@@ -1,0 +1,33 @@
+name: "Docker build test in PRs"
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  docker-build:
+    name: "Build Docker image"
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
+
+      - name: Checkout repository to build machine
+        uses: actions/checkout@v2
+
+      - name: Build and push to Docker Hub
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,8 +9,8 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  docker-build:
-    name: "Build and push Docker image"
+  docker-build-ghcr:
+    name: "Build and push Docker image to ghcr.io"
     runs-on: ubuntu-latest
 
     permissions:
@@ -54,3 +54,44 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  docker-build-hub:
+    name: "Build and push Docker image to Docker Hub"
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
+
+      - name: Checkout repository to build machine
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker Hub
+        id: meta_dockerhub
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Build and push to Docker Hub
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta_dockerhub.outputs.tags }}
+          labels: ${{ steps.meta_dockerhub.outputs.labels }}


### PR DESCRIPTION
The workflow now pushes to DockerHub and not only ghcr.io, same as the API. Also, a workflow is added to test Docker builds with PRs.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Two changes are included:
- The Docker workflow is expanded to push to DockerHub, and not only ghcr.io. This follows the already existing workflow in the API.
- A new Docker workflow is included for PRs, so that a build is tried before the PR is approved.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `jest` command?
- [x] Did you **run pre-commit hooks** with `npx prettier --write "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}"` command?

## Did you have fun?

Make sure you had fun coding 🙃
