### PR TITLE
Replace useWebsocket hook with socket.io and handle ws disconnections properly

### DIFF
--- a/src/hooks/useChatSocket.tsx
+++ b/src/hooks/useChatSocket.tsx
@@ -1,0 +1,81 @@
+'use client';
+import { useCallback, useEffect, useState } from 'react';
+
+const useChatSocket = (url: string) => {
+  const [socket, setSocket] = useState<WebSocket | null>(null);
+  const [connectionStatus, setConnectionStatus] = useState('disconnected');
+  const [lastMessage, setLastMessage] = useState<any>(null);
+
+  useEffect(() => {
+    if (!url) {
+      console.error('WebSocket connection failed: URL is required');
+      return;
+    }
+
+    let newSocket;
+    try {
+      newSocket = new WebSocket(url);
+    } catch (error) {
+      console.error('WebSocket connection failed:', error);
+      return;
+    }
+
+    newSocket.addEventListener('open', () => {
+      setConnectionStatus('connected');
+      console.log('Socket connection opened');
+    });
+
+    newSocket.addEventListener('close', () => {
+      setConnectionStatus('disconnected');
+      console.log('Socket connection closed');
+    });
+
+    newSocket.addEventListener('message', (event) => {
+      const messageData = JSON.parse(event.data);
+      setLastMessage(messageData);
+    });
+
+    newSocket.addEventListener('error', (event) => {
+      setConnectionStatus('error');
+      console.log('WebSocket error:', event);
+    });
+
+    setSocket(newSocket);
+
+    return () => {
+      if (newSocket && newSocket.readyState === WebSocket.OPEN) {
+        newSocket.close();
+      }
+    };
+  }, [url]);
+
+  useEffect(() => {
+    const closeSocket = () => {
+      if (socket && socket.readyState === WebSocket.OPEN) {
+        socket.close();
+      }
+    };
+
+    window.addEventListener('beforeunload', closeSocket);
+    return () => {
+      window.removeEventListener('beforeunload', closeSocket);
+    };
+  }, [socket]);
+
+  const sendMessage = useCallback(
+    (newMessage: string) => {
+      if (!newMessage.trim()) return;
+      if (socket && socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ query: newMessage }));
+        setLastMessage({ text: newMessage, user: 'humanUser' });
+      } else {
+        console.error('WebSocket is not open. Cannot send message.');
+      }
+    },
+    [socket],
+  );
+
+  return { sendMessage, lastMessage, connectionStatus };
+};
+
+export default useChatSocket;

--- a/src/layouts/ChatbotWebsocketStreaming.tsx
+++ b/src/layouts/ChatbotWebsocketStreaming.tsx
@@ -1,10 +1,10 @@
 'use client';
+import useChatSocket from '@/hooks/useChatSocket';
 import { ChatbotProps } from '@/types/chatbot';
 import { Message } from '@/types/message';
 import { Dialog, Divider, useMediaQuery } from '@mui/material';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import useWebSocket, { ReadyState } from 'react-use-websocket';
 import ChatbotCore from '../components/chat/ChatbotCore';
 import ChatbotInput from '../components/chat/ChatbotInput';
 
@@ -75,21 +75,10 @@ const ChatbotWebsocketStreaming: React.FC<ChatbotProps> = ({
   }, []);
 
   const wsUrl = useMemo(() => {
-    if (apiConfig.auth && token) {
-      return `${apiConfig.apiQueryEndpoint}?token=${token}`;
-    }
-    return apiConfig.apiQueryEndpoint;
+    return apiConfig.auth && token ? `${apiConfig.apiQueryEndpoint}?token=${token}` : null;
   }, [apiConfig.apiQueryEndpoint, apiConfig.auth, token]);
 
-  const { sendMessage, lastMessage, readyState } = useWebSocket(wsUrl);
-
-  const connectionStatus = {
-    [ReadyState.CONNECTING]: 'Connecting',
-    [ReadyState.OPEN]: 'Open',
-    [ReadyState.CLOSING]: 'Closing',
-    [ReadyState.CLOSED]: 'Closed',
-    [ReadyState.UNINSTANTIATED]: 'Uninstantiated',
-  }[readyState];
+  const { sendMessage, lastMessage, connectionStatus } = useChatSocket(wsUrl ?? '');
 
   const handleSendMessage = () => {
     if (!isAnyMessageLoading && messages.length % 2 == 0) {
@@ -125,7 +114,7 @@ const ChatbotWebsocketStreaming: React.FC<ChatbotProps> = ({
 
   useEffect(() => {
     if (lastMessage !== null) {
-      let messageData = JSON.parse(lastMessage.data);
+      let messageData = lastMessage;
       let mappedData: { [key: string]: any } = {};
 
       if (apiConfig.queryParams) {


### PR DESCRIPTION
The WebSocket connection in ChatbotWebsocketStreaming.tsx has been refactored to use the useChatSocket hook instead of the useWebSocket hook. This change improves the handling of WebSocket disconnections when the tab is closed or the URL changes, preventing unwanted connections from remaining open.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->
- Replace `useWebsocket` hook with `socket.io`, as it is widely maintained and a larger community.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `npm run build` and `npm test` commands?
- [x] Did you **run pre-commit hooks** with `npx prettier --write "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}"` command?
