### PR TITLE
Add preloadedMessages prop to ChatbotWebsocketStreaming component

### DIFF
--- a/out/src/app/streaming/page.js
+++ b/out/src/app/streaming/page.js
@@ -12,6 +12,12 @@ function Home() {
     const [initializedChat, setInitializedChat] = react_1.default.useState(false);
     const [chatData, setChatData] = react_1.default.useState(null);
     const themeConfig = ChatbotDefaultTheme_1.default;
+    const preloadedMessages = [
+        {
+            text: 'Hello! How can I help you today?',
+            user: 'humanUser',
+        },
+    ];
     return (react_1.default.createElement("main", { style: {
             display: 'flex',
             justifyContent: 'center',
@@ -22,7 +28,7 @@ function Home() {
         } },
         react_1.default.createElement("div", { style: { width: '20vw', height: '100%' } }),
         react_1.default.createElement("div", { style: { width: '100%', height: '100%' } },
-            react_1.default.createElement(ChatbotWebsocketStreaming_1.default, { apiConfig: {
+            react_1.default.createElement(ChatbotWebsocketStreaming_1.default, { preloadedMessages: preloadedMessages, apiConfig: {
                     auth: true,
                     tokenName: 'userToken',
                     fetchFunction: '',

--- a/out/src/layouts/ChatbotWebsocketStreaming.js
+++ b/out/src/layouts/ChatbotWebsocketStreaming.js
@@ -33,7 +33,7 @@ const styles_1 = require("@mui/material/styles");
 const react_1 = __importStar(require("react"));
 const ChatbotCore_1 = __importDefault(require("../components/chat/ChatbotCore"));
 const ChatbotInput_1 = __importDefault(require("../components/chat/ChatbotInput"));
-const ChatbotWebsocketStreaming = ({ className, apiConfig, themeConfig, welcomeMessageRenderFunction, setDataForParent, onApiResponseCode, botMessageRenderFunction, userMessageRenderFunction, dataRenderFunction, referenceRenderFunction, relatedQuestionsRenderFunction, errorRenderFunction, }) => {
+const ChatbotWebsocketStreaming = ({ className, apiConfig, themeConfig, preloadedMessages, welcomeMessageRenderFunction, setDataForParent, onApiResponseCode, botMessageRenderFunction, userMessageRenderFunction, dataRenderFunction, referenceRenderFunction, relatedQuestionsRenderFunction, errorRenderFunction, }) => {
     var _a, _b, _c, _d;
     const ErrorRender = (0, react_1.useCallback)((error) => {
         return errorRenderFunction ? (errorRenderFunction(error)) : (react_1.default.createElement(material_1.Dialog, { open: true },
@@ -49,7 +49,7 @@ const ChatbotWebsocketStreaming = ({ className, apiConfig, themeConfig, welcomeM
     const botUser = 'botUser';
     const isMobile = (0, material_1.useMediaQuery)('(max-width:750px)');
     const customTheme = (0, styles_1.createTheme)(themeConfig ? { palette: themeConfig.palette, typography: themeConfig.typography } : {});
-    const [messages, setMessages] = (0, react_1.useState)([]);
+    const [messages, setMessages] = (0, react_1.useState)(preloadedMessages !== null && preloadedMessages !== void 0 ? preloadedMessages : []);
     const [newMessage, setNewMessage] = (0, react_1.useState)('');
     const [botMessage, setBotMessage] = (0, react_1.useState)(null);
     const messagesEndRef = (0, react_1.useRef)(null);

--- a/out/src/types/chatbot.d.ts
+++ b/out/src/types/chatbot.d.ts
@@ -32,6 +32,7 @@ export interface ChatbotProps {
     style?: React.CSSProperties;
     apiConfig: APIConfig;
     themeConfig: ThemeConfig;
+    preloadedMessages?: Message[];
     sendCustomMessage?: (text: string) => void;
     welcomeMessageRenderFunction?: (sendCustomMessage: any) => JSX.Element;
     setDataForParent?: (data: any) => void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gptstonks/chatbot",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gptstonks/chatbot",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gptstonks/chatbot",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "author": {
     "name": "GPTStonks",
     "email": "gptstonks@gmail.com"

--- a/src/app/streaming/page.tsx
+++ b/src/app/streaming/page.tsx
@@ -11,6 +11,13 @@ export default function Home() {
 
   const themeConfig = useChatbotDefaultTheme;
 
+  const preloadedMessages: Message[] = [
+    {
+      text: 'Hello! How can I help you today?',
+      user: 'humanUser',
+    },
+  ];
+
   return (
     <main
       style={{
@@ -25,6 +32,7 @@ export default function Home() {
       <div style={{ width: '20vw', height: '100%' }}></div>
       <div style={{ width: '100%', height: '100%' }}>
         <ChatbotWebsocketStreaming
+          preloadedMessages={preloadedMessages}
           apiConfig={{
             auth: true,
             tokenName: 'userToken',

--- a/src/layouts/ChatbotWebsocketStreaming.tsx
+++ b/src/layouts/ChatbotWebsocketStreaming.tsx
@@ -12,6 +12,7 @@ const ChatbotWebsocketStreaming: React.FC<ChatbotProps> = ({
   className,
   apiConfig,
   themeConfig,
+  preloadedMessages,
   welcomeMessageRenderFunction,
   setDataForParent,
   onApiResponseCode,
@@ -49,7 +50,7 @@ const ChatbotWebsocketStreaming: React.FC<ChatbotProps> = ({
   const customTheme = createTheme(
     themeConfig ? { palette: themeConfig.palette, typography: themeConfig.typography } : {},
   );
-  const [messages, setMessages] = useState<Message[]>([]);
+  const [messages, setMessages] = useState<Message[]>(preloadedMessages ?? []);
   const [newMessage, setNewMessage] = useState<string>('');
   const [botMessage, setBotMessage] = useState<Message | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);

--- a/src/types/chatbot.ts
+++ b/src/types/chatbot.ts
@@ -35,6 +35,7 @@ export interface ChatbotProps {
   style?: React.CSSProperties;
   apiConfig: APIConfig;
   themeConfig: ThemeConfig;
+  preloadedMessages?: Message[];
   sendCustomMessage?: (text: string) => void;
   welcomeMessageRenderFunction?: (sendCustomMessage: any) => JSX.Element;
   setDataForParent?: (data: any) => void;


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new `preloadedMessages` prop to the `ChatbotWebsocketStreaming` component. This enhancement allows for the initialization of saved messages within the chatbot, enabling users to view and continue their conversations seamlessly.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `npm run build` and `npm run lint` commands?
- [x] Did you **run pre-commit hooks** with `npx prettier --write "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}"` command?