### PR TITLE
Enhance ChatbotWebsocketStreaming to Store and Display Last User and Bot Messages

### DIFF
--- a/out/src/components/chat/ChatbotCore.js
+++ b/out/src/components/chat/ChatbotCore.js
@@ -121,13 +121,11 @@ const ChatbotCore = ({ messages, themeConfig, isMobile, botUser, humanUser, botM
                                 } }, BotMessageRender(message, (_10 = messages[index - 1]) === null || _10 === void 0 ? void 0 : _10.text)))),
                             react_1.default.createElement(material_1.Box, { sx: {
                                     display: 'flex',
-                                } }, (message.reference) &&
-                                ReferenceRender(message.reference)),
+                                } }, message.reference && ReferenceRender(message.reference)),
                             (message.streamCompleted || message.stream) && DataRender(message.graphData)),
                         react_1.default.createElement(material_1.Box, { sx: {
                                 display: 'flex',
-                            } }, (message.related) &&
-                            RelatedQuestionsRender(message.related, sendCustomMessage)))) : (react_1.default.createElement(material_1.Box, { sx: (_12 = (_11 = themeConfig === null || themeConfig === void 0 ? void 0 : themeConfig.components) === null || _11 === void 0 ? void 0 : _11.MessageBubbleUser) === null || _12 === void 0 ? void 0 : _12.style }, UserMessageRender(message.text)))));
+                            } }, message.related && RelatedQuestionsRender(message.related, sendCustomMessage)))) : (react_1.default.createElement(material_1.Box, { sx: (_12 = (_11 = themeConfig === null || themeConfig === void 0 ? void 0 : themeConfig.components) === null || _11 === void 0 ? void 0 : _11.MessageBubbleUser) === null || _12 === void 0 ? void 0 : _12.style }, UserMessageRender(message.text)))));
             }),
             botMessage && isAnyMessageLoading && !showLinearLoader && (react_1.default.createElement(material_1.ListItem, { sx: {
                     display: 'flex',

--- a/out/src/layouts/ChatbotWebsocketStreaming.js
+++ b/out/src/layouts/ChatbotWebsocketStreaming.js
@@ -52,6 +52,8 @@ const ChatbotWebsocketStreaming = ({ className, apiConfig, themeConfig, preloade
     const [messages, setMessages] = (0, react_1.useState)(preloadedMessages !== null && preloadedMessages !== void 0 ? preloadedMessages : []);
     const [newMessage, setNewMessage] = (0, react_1.useState)('');
     const [botMessage, setBotMessage] = (0, react_1.useState)(null);
+    const [lastUserMessage, setLastUserMessage] = (0, react_1.useState)(null);
+    const [lastBotMessage, setLastBotMessage] = (0, react_1.useState)(null);
     const messagesEndRef = (0, react_1.useRef)(null);
     const [isAnyMessageLoading, setIsAnyMessageLoading] = (0, react_1.useState)(false);
     const [showLinearLoader, setShowLinearLoader] = (0, react_1.useState)(false);
@@ -83,6 +85,7 @@ const ChatbotWebsocketStreaming = ({ className, apiConfig, themeConfig, preloade
             sendMessage(JSON.stringify({ query: newMessage }));
             const userMessage = { text: newMessage, user: humanUser, loading: false };
             setMessages((prevMessages) => [...prevMessages, userMessage]);
+            setLastUserMessage(newMessage);
             setNewMessage('');
         }
         else {
@@ -96,6 +99,7 @@ const ChatbotWebsocketStreaming = ({ className, apiConfig, themeConfig, preloade
             sendMessage(JSON.stringify({ query: message }));
             const userMessage = { text: message, user: humanUser, loading: false };
             setMessages((prevMessages) => [...prevMessages, userMessage]);
+            setLastUserMessage(message);
             setNewMessage('');
         }
         else {
@@ -126,7 +130,8 @@ const ChatbotWebsocketStreaming = ({ className, apiConfig, themeConfig, preloade
             let reference = mappedData.reference;
             //console.log('data:', mappedData);
             if (setDataForParent) {
-                setDataForParent(mappedData);
+                setDataForParent(Object.assign(Object.assign({}, mappedData), { isAnyMessageLoading,
+                    lastUserMessage, lastBotMessage: body }));
             }
             if (type === 'data' && data) {
                 setGraphData(data);
@@ -176,6 +181,7 @@ const ChatbotWebsocketStreaming = ({ className, apiConfig, themeConfig, preloade
                     return updatedMessages;
                 });
                 setBotMessage(null);
+                setLastBotMessage(body);
             }
             else if (type === 'stream_step') {
                 const accumulatedStreamData = body;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gptstonks/chatbot",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gptstonks/chatbot",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gptstonks/chatbot",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "author": {
     "name": "GPTStonks",
     "email": "gptstonks@gmail.com"

--- a/src/layouts/ChatbotWebsocketStreaming.tsx
+++ b/src/layouts/ChatbotWebsocketStreaming.tsx
@@ -55,6 +55,8 @@ const ChatbotWebsocketStreaming: React.FC<ChatbotProps> = ({
   const [messages, setMessages] = useState<Message[]>(preloadedMessages ?? []);
   const [newMessage, setNewMessage] = useState<string>('');
   const [botMessage, setBotMessage] = useState<Message | null>(null);
+  const [lastUserMessage, setLastUserMessage] = useState<string | null>(null);
+  const [lastBotMessage, setLastBotMessage] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const [isAnyMessageLoading, setIsAnyMessageLoading] = useState(false);
   const [showLinearLoader, setShowLinearLoader] = useState(false);
@@ -93,6 +95,7 @@ const ChatbotWebsocketStreaming: React.FC<ChatbotProps> = ({
 
       const userMessage = { text: newMessage, user: humanUser, loading: false };
       setMessages((prevMessages) => [...prevMessages, userMessage]);
+      setLastUserMessage(newMessage);
       setNewMessage('');
     } else {
       console.log('Some message is still loading or connection is not established.');
@@ -106,6 +109,7 @@ const ChatbotWebsocketStreaming: React.FC<ChatbotProps> = ({
 
       const userMessage = { text: message, user: humanUser, loading: false };
       setMessages((prevMessages) => [...prevMessages, userMessage]);
+      setLastUserMessage(message);
       setNewMessage('');
     } else {
       console.log('Some message is still loading or connection is not established.');
@@ -140,7 +144,12 @@ const ChatbotWebsocketStreaming: React.FC<ChatbotProps> = ({
       //console.log('data:', mappedData);
 
       if (setDataForParent) {
-        setDataForParent(mappedData);
+        setDataForParent({
+          ...mappedData,
+          isAnyMessageLoading,
+          lastUserMessage,
+          lastBotMessage: body,
+        });
       }
 
       if (type === 'data' && data) {
@@ -201,6 +210,7 @@ const ChatbotWebsocketStreaming: React.FC<ChatbotProps> = ({
           return updatedMessages;
         });
         setBotMessage(null);
+        setLastBotMessage(body);
       } else if (type === 'stream_step') {
         const accumulatedStreamData = body;
 


### PR DESCRIPTION
## What does this PR do?

This PR enhances the `ChatbotWebsocketStreaming` component by adding state variables to store the last user and bot messages. It updates the logic to set these variables when new messages are sent or received, facilitating easier access and display of the last messages in the chatbot interface.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `npm run build` and `npm run lint` commands?
- [x] Did you **run pre-commit hooks** with `npx prettier --write "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}"` command?